### PR TITLE
Bump binary-search-bounds v2

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "binary-search-bounds": "^1.0.0",
+    "binary-search-bounds": "^2.0.0",
     "functional-red-black-tree": "^1.0.0",
     "robust-orientation": "^1.1.3"
   },


### PR DESCRIPTION
Bump `binary-search-bounds` to v2 which has no function constructors.
@mikolalysenko 

cc: @alexcjohnson
cc: plotly/plotly.js#897
cc: https://github.com/mikolalysenko/binary-search-bounds/pull/8
